### PR TITLE
[Chore] Shorten link title

### DIFF
--- a/docs/registry/attributes/README.md
+++ b/docs/registry/attributes/README.md
@@ -1,4 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Attributes
 auto_gen: below
 --->
 


### PR DESCRIPTION
## Changes

This should result in the link title to simply be **Attributes** rather than **Attribute Registry** with the registry part being redundant given a user has already selected registries in the left navigation as well as it appearing as the previous breadcrumb.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.
